### PR TITLE
Update encoding format

### DIFF
--- a/protocol/03_encoding.md
+++ b/protocol/03_encoding.md
@@ -30,7 +30,7 @@ The information here is used to receive the data JSON.
 | CRC32  | CRC32 checksum over the buffer of the 2nd JSON string.  | `uint32` or `int64` |
 | type_id| The type of the message.                                | `uint8` or `int16`  |
 
-To ensure that the header is always 50 characters long, all values are encoded as strings with leading zeros. The number of digits depends on the largest possible number of these values. Both values must be treated as unsigned integers. If the chosen programming language does not support this, a larger data type must be selected. The recommended types are listed in the table above.
+To ensure that the header is always 64 characters long, all values are encoded as strings with leading zeros. The number of digits depends on the largest possible number of these values. Both values must be treated as unsigned integers. If the chosen programming language does not support this, a larger data type must be selected. The recommended types are listed in the table above.
 
 ### Packet Type
 The `type_id` field is used to determine the type of the message. The following types are defined:
@@ -48,8 +48,8 @@ This JSON contains the payload. Its content is defined by the appropriate sectio
 
 ## Handling Headers
 
-If a client is sending a message, it should first write a header. To do this, the size of the string-formatted JSON data and the CRC32 checksum of this data must be calculated and packed into a JSON-formatted header. This header must be aligned to 50 bytes as stated above. The header and the data are then sent immediately one after the other, with the header preceding the data (encapsulation).
+If a client is sending a message, it should first write a header. To do this, the size of the string-formatted JSON data and the CRC32 checksum of this data must be calculated and packed into a JSON-formatted header. This header must be aligned to 128 bytes as stated above. The header and the data are then sent immediately one after the other, with the header preceding the data (encapsulation).
 
-If a client is receiving a message, it should read 50 bytes from the input buffer to receive the header. After reading the data size from the header, the client can start reading the data section of the message using the data size. Then, the CRC32 checksum of the data section should be calculated and compared to the checksum specified in the header:  
+If a client is receiving a message, it should read 128 bytes from the input buffer to receive the header. After reading the data size from the header, the client can start reading the data section of the message using the data size. Then, the CRC32 checksum of the data section should be calculated and compared to the checksum specified in the header:  
 If the checksums are equal, the client can proceed with further processing, such as message forwarding or updating the routing table.  
 If the checksums are not equal, the message can be discarded and ignored.

--- a/protocol/03_encoding.md
+++ b/protocol/03_encoding.md
@@ -32,3 +32,12 @@ To ensure that the header is always 50 characters long, all values are encoded a
 This JSON contains the payload. Its content is defined by the appropriate sections.
 
 ## Example
+
+
+## Handling Headers
+
+If a client is sending a message, it should first write a header. To do this, the size of the string-formatted JSON data and the CRC32 checksum of this data must be calculated and packed into a JSON-formatted header. This header must be aligned to 50 bytes as stated above. The header and the data are then sent immediately one after the other, with the header preceding the data (encapsulation).
+
+If a client is receiving a message, it should read 50 bytes from the input buffer to receive the header. After reading the data size from the header, the client can start reading the data section of the message using the data size. Then, the CRC32 checksum of the data section should be calculated and compared to the checksum specified in the header:  
+If the checksums are equal, the client can proceed with further processing, such as message forwarding or updating the routing table.  
+If the checksums are not equal, the message can be discarded and ignored.

--- a/protocol/03_encoding.md
+++ b/protocol/03_encoding.md
@@ -6,18 +6,29 @@
 - ...
 
 ## Format
+A message is made up of two JSON strings, one for the header and the other for the data.
+
 ### Header
-| Type  | Name      | Description                                      |
-|-------|-----------|--------------------------------------------------|
-| int_? | Length    | Message length (including or excluding?) header. | 
-| int_? | Checksum  | ...                                              |
-TODO:
-- Define int sizes. The length cannot exceed the uint16 range. However, it may be more convenient to use int32 in languages that do not support unsigned types.
-- Select a checksum algorithm.
+The header is always 50 characters long. This allows the receiving side to first fill an input buffer with the data for exactly one JSON string, and extract further information from there. The content of the header is `{"Header":{"Length":"01234","CRC32":"0123456789"}}`, or formatted to look more legible:
+```json
+{
+  "Header": {
+      "Length": "01234",
+      "CRC32" : "0123456789"
+    }
+}
+```
+
+The information here is used to receive the data JSON.
+
+| Name   | Description                                             | Target Type         |
+|--------|---------------------------------------------------------|---------------------|
+| Length | Length of the 2nd JSON string (Data) in bytes.          | `uint16` or `int32` | 
+| CRC32  | CRC32 checksum over the buffer of the 2nd JSON string.  | `uint32` or `int64` |
+
+To ensure that the header is always 50 characters long, all values are encoded as strings with leading zeros. The number of digits depends on the largest possible number of these values. Both values must be treated as unsigned integers. If the chosen programming language does not support this, a larger data type must be selected. The recommended types are listed in the table above.
 
 ### Data
-| Type    | Name | Description                             |
-|---------|------|-----------------------------------------|
-| String  | Data | JSON message encoded as a UTF-8 string. |
+This JSON contains the payload. Its content is defined by the appropriate sections.
 
 ## Example

--- a/protocol/03_encoding.md
+++ b/protocol/03_encoding.md
@@ -9,7 +9,7 @@
 A message is made up of two JSON strings, one for the header and the other for the data.
 
 ### Header
-The header is always 64 _UTF-16_ characters long. That means the payload should be exactly 128 bytes long, encoded big endian. 
+The header is always 64 _UTF-8_ characters long. That means the payload should be exactly 64 bytes long, encoded big endian. 
 
 This allows the receiving side to first fill an input buffer with the data for exactly one JSON string, and extract further information from there. The content of the header is `{"Header":{"Length":"01234","CRC32":"0123456789","type_id":"1"}}`, or formatted to look more legible:
 ```json
@@ -28,7 +28,7 @@ The information here is used to receive the data JSON.
 |--------|---------------------------------------------------------|---------------------|
 | Length | Length of the 2nd JSON string (Data) in bytes.          | `uint16` or `int32` | 
 | CRC32  | CRC32 checksum over the buffer of the 2nd JSON string.  | `uint32` or `int64` |
-| type_id| The type of the message.                                | `uint8` or `int16`  |
+| type_id| The type of the message.                                | `byte (u8)`         |
 
 To ensure that the header is always 64 characters long, all values are encoded as strings with leading zeros. The number of digits depends on the largest possible number of these values. Both values must be treated as unsigned integers. If the chosen programming language does not support this, a larger data type must be selected. The recommended types are listed in the table above.
 
@@ -48,8 +48,8 @@ This JSON contains the payload. Its content is defined by the appropriate sectio
 
 ## Handling Headers
 
-If a client is sending a message, it should first write a header. To do this, the size of the string-formatted JSON data and the CRC32 checksum of this data must be calculated and packed into a JSON-formatted header. This header must be aligned to 128 bytes as stated above. The header and the data are then sent immediately one after the other, with the header preceding the data (encapsulation).
+If a client is sending a message, it should first write a header. To do this, the size of the string-formatted JSON data and the CRC32 checksum of this data must be calculated and packed into a JSON-formatted header. This header must be aligned to 64 bytes as stated above. The header and the data are then sent immediately one after the other, with the header preceding the data (encapsulation).
 
-If a client is receiving a message, it should read 128 bytes from the input buffer to receive the header. After reading the data size from the header, the client can start reading the data section of the message using the data size. Then, the CRC32 checksum of the data section should be calculated and compared to the checksum specified in the header:  
+If a client is receiving a message, it should read 64 bytes from the input buffer to receive the header. After reading the data size from the header, the client can start reading the data section of the message using the data size. Then, the CRC32 checksum of the data section should be calculated and compared to the checksum specified in the header:  
 If the checksums are equal, the client can proceed with further processing, such as message forwarding or updating the routing table.  
 If the checksums are not equal, the message can be discarded and ignored.

--- a/protocol/03_encoding.md
+++ b/protocol/03_encoding.md
@@ -9,12 +9,15 @@
 A message is made up of two JSON strings, one for the header and the other for the data.
 
 ### Header
-The header is always 50 characters long. This allows the receiving side to first fill an input buffer with the data for exactly one JSON string, and extract further information from there. The content of the header is `{"Header":{"Length":"01234","CRC32":"0123456789"}}`, or formatted to look more legible:
+The header is always 64 _UTF-16_ characters long. That means the payload should be exactly 128 bytes long, encoded big endian. 
+
+This allows the receiving side to first fill an input buffer with the data for exactly one JSON string, and extract further information from there. The content of the header is `{"Header":{"Length":"01234","CRC32":"0123456789","type_id":"1"}}`, or formatted to look more legible:
 ```json
 {
   "Header": {
       "Length": "01234",
-      "CRC32" : "0123456789"
+      "CRC32" : "0123456789",
+      "type_id": "1"
     }
 }
 ```
@@ -25,8 +28,17 @@ The information here is used to receive the data JSON.
 |--------|---------------------------------------------------------|---------------------|
 | Length | Length of the 2nd JSON string (Data) in bytes.          | `uint16` or `int32` | 
 | CRC32  | CRC32 checksum over the buffer of the 2nd JSON string.  | `uint32` or `int64` |
+| type_id| The type of the message.                                | `uint8` or `int16`  |
 
 To ensure that the header is always 50 characters long, all values are encoded as strings with leading zeros. The number of digits depends on the largest possible number of these values. Both values must be treated as unsigned integers. If the chosen programming language does not support this, a larger data type must be selected. The recommended types are listed in the table above.
+
+### Packet Type
+The `type_id` field is used to determine the type of the message. The following types are defined:
+
+| ID | Type          | Description                |
+|----|---------------|----------------------------|
+| 1  | Routing       | Routing Packet             |
+| 2  | Routed        | Routed Packet              |
 
 ### Data
 This JSON contains the payload. Its content is defined by the appropriate sections.


### PR DESCRIPTION
Changed the header format to use JSON, too. The constant length is archived by storing the values as strings of fixed size (with leading zeros).